### PR TITLE
Improve alignment memory handling

### DIFF
--- a/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
@@ -124,7 +124,14 @@ public class PeakAligner {
         ChromatogramSerializer<ChromatogramPeakInfo> serializer = null) {
 
         var provider = ProviderFactory?.Create(analysisFile);
-        IReadOnlyList<RawSpectrum> spectra = provider?.LoadMs1Spectrums();
+        IReadOnlyList<RawSpectrum> spectra = null;
+        try {
+            spectra = provider?.LoadMs1Spectrums();
+        } finally {
+            if (provider is IDisposable disposable) {
+                disposable.Dispose();
+            }
+        }
         if (spectra == null) {
             using (var rawDataAccess = new RawDataAccess(analysisFile.AnalysisFilePath, 0, false, false, true, analysisFile.RetentionTimeCorrectionBean.PredictedRt)) {
                 spectra = rawDataAccess.GetMeasurement()?.SpectrumList;

--- a/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
@@ -123,15 +123,10 @@ public class PeakAligner {
         string tempFile,
         ChromatogramSerializer<ChromatogramPeakInfo> serializer = null) {
 
-        var provider = ProviderFactory?.Create(analysisFile);
-        IReadOnlyList<RawSpectrum> spectra = null;
-        try {
+        using (var provider = ProviderFactory?.Create(analysisFile)) {
             spectra = provider?.LoadMs1Spectrums();
-        } finally {
-            if (provider is IDisposable disposable) {
-                disposable.Dispose();
-            }
         }
+        
         if (spectra == null) {
             using (var rawDataAccess = new RawDataAccess(analysisFile.AnalysisFilePath, 0, false, false, true, analysisFile.RetentionTimeCorrectionBean.PredictedRt)) {
                 spectra = rawDataAccess.GetMeasurement()?.SpectrumList;

--- a/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakJoiner.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakJoiner.cs
@@ -57,6 +57,7 @@ namespace CompMs.MsdialCore.Algorithm.Alignment
             foreach (var analysisFile in analysisFiles) {
                 var chromatogram = accessor.GetMSScanProperties(analysisFile);
                 AlignPeaksToMaster(result, master, chromatogram, analysisFile.AnalysisFileId);
+                chromatogram.Clear();
             }
             
             return result;
@@ -68,11 +69,15 @@ namespace CompMs.MsdialCore.Algorithm.Alignment
             if (referenceFile == null) return new List<IMSScanProperty>();
 
             var master = new List<IMSScanProperty>();
-            master = MergeChromatogramPeaks(master, accessor.GetMSScanProperties(referenceFile));
+            var chromatogram = accessor.GetMSScanProperties(referenceFile);
+            master = MergeChromatogramPeaks(master, chromatogram);
+            chromatogram.Clear();
             foreach (var analysisFile in analysisFiles) {
                 if (analysisFile.AnalysisFileId == referenceFile.AnalysisFileId)
                     continue;
-                master = MergeChromatogramPeaks(master, accessor.GetMSScanProperties(analysisFile));
+                chromatogram = accessor.GetMSScanProperties(analysisFile);
+                master = MergeChromatogramPeaks(master, chromatogram);
+                chromatogram.Clear();
             }
 
             return master;

--- a/src/MSDIAL5/MsdialCore/Algorithm/BaseDataProvider.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/BaseDataProvider.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace CompMs.MsdialCore.Algorithm
 {
-    public abstract class BaseDataProvider : IDataProvider
+    public abstract class BaseDataProvider : IDataProvider, IDisposable
     {
         private readonly Task<IList<RawSpectrum>> _spectraTask;
 
@@ -113,6 +113,12 @@ namespace CompMs.MsdialCore.Algorithm
                         : await _spectraTask.ConfigureAwait(false);
                     return spectra.Where(spectrum => spectrum.MsLevel == level).ToList().AsReadOnly();
                 })).Value;
+
+        public virtual void Dispose() {
+            cache.Clear();
+            if (_spectraTask.IsCompleted) {
+                _spectraTask.Result.Clear();
+            }
         }
     }
 }

--- a/src/MSDIAL5/MsdialCore/Algorithm/BaseDataProvider.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/BaseDataProvider.cs
@@ -116,7 +116,7 @@ namespace CompMs.MsdialCore.Algorithm
 
         public virtual void Dispose() {
             cache.Clear();
-            if (_spectraTask.IsCompleted) {
+            if (_spectraTask.IsCompleted && _spectraTask.Result != null) {
                 _spectraTask.Result.Clear();
             }
         }

--- a/src/MSDIAL5/MsdialCore/Algorithm/Internal/CachedDataProvider.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Internal/CachedDataProvider.cs
@@ -24,7 +24,7 @@ namespace CompMs.MsdialCore.Algorithm.Internal;
 /// that spectra data is cached the first time it is requested through this provider.
 /// </para>
 /// </remarks>
-internal sealed class CachedDataProvider: IDataProvider
+internal sealed class CachedDataProvider : IDataProvider, IDisposable
 {
     private readonly IDataProvider _provider;
 
@@ -111,4 +111,14 @@ internal sealed class CachedDataProvider: IDataProvider
     private async Task<ReadOnlyCollection<RawSpectrum>> LoadMsSpectrumsAsyncCore(CancellationToken token) {
         return _msSpectraCache = await _provider.LoadMsSpectrumsAsync(token).ConfigureAwait(false);
     }
+    public void Dispose() {
+        _ms1SpectraCache = null;
+        _ms2SpectraCache = null;
+        _msSpectraCache = null;
+        _msnSpectraCaches.Clear();
+        if (_provider is IDisposable disposable) {
+            disposable.Dispose();
+        }
+    }
+
 }

--- a/src/MSDIAL5/MsdialCore/DataObj/ChromatogramPeakFeature.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/ChromatogramPeakFeature.cs
@@ -130,7 +130,7 @@ namespace CompMs.MsdialCore.DataObj
         public ChromXs ChromXs { get => PeakFeature.ChromXsTop; set => PeakFeature.ChromXsTop = value; } // same as ChromXsTop
         // Spectrum data for serialization. Use the Spectrum property to access at runtime.
         [Key(24)]
-        public List<SpectrumPeak> SerializedSpectrum { get; set; } = null;
+        public List<SpectrumPeak> Spectrum { get; set; } = new List<SpectrumPeak>();
 
         private List<SpectrumPeak> _runtimeLoadedSpectrum;
         private bool _spectrumProviderLoadAttempted = false;

--- a/src/MSDIAL5/MsdialCore/DataObj/ChromatogramPeakFeature.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/ChromatogramPeakFeature.cs
@@ -130,7 +130,7 @@ namespace CompMs.MsdialCore.DataObj
         public ChromXs ChromXs { get => PeakFeature.ChromXsTop; set => PeakFeature.ChromXsTop = value; } // same as ChromXsTop
         // Spectrum data for serialization. Use the Spectrum property to access at runtime.
         [Key(24)]
-        public List<SpectrumPeak> Spectrum { get; set; } = new List<SpectrumPeak>();
+        public List<SpectrumPeak> SerializedSpectrum { get; set; } = null;
 
         private List<SpectrumPeak> _runtimeLoadedSpectrum;
         private bool _spectrumProviderLoadAttempted = false;

--- a/src/MSDIAL5/MsdialCore/Parser/MsdialPeakSerializer.cs
+++ b/src/MSDIAL5/MsdialCore/Parser/MsdialPeakSerializer.cs
@@ -10,6 +10,9 @@ namespace CompMs.MsdialCore.Parser
     public static class MsdialPeakSerializer
     {
         public static void SaveChromatogramPeakFeatures(string file, List<ChromatogramPeakFeature> chromPeakFeatures) {
+            foreach (var peak in chromPeakFeatures.SelectMany(Flatten)) {
+                peak.PrepareForSerialization();
+            }
             MessagePackHandler.SaveToFile<List<ChromatogramPeakFeature>>(chromPeakFeatures, file);
             var tagfile = Path.Combine(Path.GetDirectoryName(file), Path.GetFileNameWithoutExtension(file) + "_tags.xml");
             var defsElement = new XElement("Definitions");


### PR DESCRIPTION
## Summary
- dispose data providers to clear cached spectra
- avoid duplicating spectra in ChromatogramPeakFeature
- free per‑file chromatograms during peak joining

## Testing
- `dotnet build --no-restore --no-incremental` *(fails: reference assemblies missing)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68416064a5b483249a0d80d136d67e3e

## Sourcery 요약

데이터 공급자를 삭제하고, 캐시된 스펙트럼 및 크로마토그램을 정리하고, 스펙트럼 직렬화를 최적화하여 정렬 중 메모리 관리를 개선합니다.

버그 수정:
- ChromatogramPeakFeature.AddPeak에서 중복된 스펙트럼 항목을 방지합니다.

개선 사항:
- 직렬화된 데이터와 런타임 캐시를 분리하고 지울 수 있도록 하여 ChromatogramPeakFeature에서 스펙트럼의 지연 로딩을 도입합니다.
- CachedDataProvider 및 BaseDataProvider에 IDisposable을 구현하고 PeakAligner에서 IDataProvider 인스턴스를 삭제하여 캐시된 스펙트럼을 해제합니다.
- PeakJoiner에서 병합 및 결합 후 파일별 크로마토그램을 정리하여 메모리를 확보합니다.
- 내보낼 때 캐시된 스펙트럼을 정리하기 위해 크로마토그램 피크 특징을 저장하기 전에 PrepareForSerialization을 호출합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve memory handling during alignment by disposing data providers, clearing cached spectra and chromatograms, and optimizing spectrum serialization.

Bug Fixes:
- Prevent duplicated spectrum entries in ChromatogramPeakFeature.AddPeak.

Enhancements:
- Introduce lazy-loading of spectra in ChromatogramPeakFeature by separating serialized data and runtime cache and allowing it to be cleared.
- Implement IDisposable on CachedDataProvider and BaseDataProvider and dispose of IDataProvider instances in PeakAligner to release cached spectra.
- Clear per-file chromatograms after merging and joining in PeakJoiner to free memory.
- Invoke PrepareForSerialization before saving chromatogram peak features to clear cached spectra when exporting.

</details>